### PR TITLE
#1 Handle empty property strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": false,
   "scripts": {
     "test": "jest",
+    "dev": "ts-node ./src/dev/dev.ts",
     "build": "rimraf ./build && tsc"
   },
   "devDependencies": {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -5,12 +5,14 @@ const extractProperty = (
   inputObj: InputObject,
   properties: string | number | (string | number)[],
   fallback?: any
-): BasicObject | string | number | boolean | any[] | Function => {
+): BasicObject | string | number | boolean | any[] | InputObject | Function => {
   const propertyPathArray = Array.isArray(properties)
     ? properties
     : splitPropertyString(properties as string)
 
   const currentProperty = propertyPathArray[0]
+
+  if (currentProperty === '') return inputObj
 
   if (Array.isArray(inputObj) && typeof currentProperty !== 'number')
     return inputObj.map((item) => extractProperty(item, propertyPathArray, fallback))

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -50,6 +50,15 @@ test('Deep props 2', () => {
   expect(extract(testObj1, 'b.inner3.innerDeep')).toBe(2.4)
 })
 
+// Get inner objects
+test('Get inner object, shallow', () => {
+  expect(extract(testObj1, 'a')).toStrictEqual(testObj1.a)
+})
+
+test('Get inner object, deeper', () => {
+  expect(extract(testObj1, 'b.inner3')).toStrictEqual(testObj1.b.inner3)
+})
+
 // Get arrays, various depths
 test('Array at top level', () => {
   expect(extract(testObj1, 'ee')).toStrictEqual([1, 'two', { three: 4 }, false, undefined, null])
@@ -84,6 +93,15 @@ test('Array at top level (object is array)', () => {
 
 test('Array at top level (object is array), with nested elements', () => {
   expect(extract(arrayObj, '[2].one.y')).toStrictEqual(['Why', 'YYY'])
+})
+
+// Empty property strings
+test('Empty property string', () => {
+  expect(extract(testObj1, '')).toStrictEqual(testObj1)
+})
+
+test('Empty property string after .', () => {
+  expect(extract(testObj1, 'b.inner3.')).toStrictEqual(testObj1.b.inner3)
 })
 
 // Run a function in an object
@@ -153,11 +171,6 @@ test('Empty input object, no fallback', () => {
 
 test('Empty input object, with fallback', () => {
   expect(extract({}, 'topLevel', 'alternative')).toBe('alternative')
-})
-
-// Handle empty string
-test('Property is empty string', () => {
-  expect(extract(testObj1, '', 'Fallback')).toBe('Fallback')
 })
 
 // Handle undefined


### PR DESCRIPTION
Fix #1 

Empty property strings (at any level) just return the whole object (at that level)